### PR TITLE
DynamicSegtree 系の空間計算量の改善

### DIFF
--- a/Structure/dynamic-dualsegtree.cpp
+++ b/Structure/dynamic-dualsegtree.cpp
@@ -1,4 +1,6 @@
-#include <algorithm>
+struct DynamicDualSeg;
+// 必ず vec でなく deque で
+deque<DynamicDualSeg> alloc;
 
 struct DynamicDualSeg {
   DynamicDualSeg *lc = 0, *rc = 0;
@@ -12,8 +14,8 @@ struct DynamicDualSeg {
   void _() {
     if (!lc) {
       ll mid = (l + r) / 2;
-      lc = new DynamicDualSeg(l, mid);
-      rc = new DynamicDualSeg(mid, r);
+      alloc.emplace_back(l, mid); lc = &alloc.back();
+      alloc.emplace_back(mid, r); rc = &alloc.back();
     }
     lc->effect(l, r, m), rc->effect(l, r, m), m = id;
   }

--- a/Structure/dynamic-lazysegtree.cpp
+++ b/Structure/dynamic-lazysegtree.cpp
@@ -1,3 +1,7 @@
+struct DynamicLazySeg;
+// 必ず vec でなく deque で
+deque<DynamicLazySeg> alloc;
+
 struct DynamicLazySeg {
   DynamicLazySeg *lc = 0, *rc = 0;
   ll l, r;
@@ -12,8 +16,8 @@ struct DynamicLazySeg {
   void _() {
     if (!lc) {
       ll m = l + (r - l) / 2;
-      lc = new DynamicLazySeg(l, m);
-      rc = new DynamicLazySeg(m, r);
+      alloc.emplace_back(l, m); lc = &alloc.back();
+      alloc.emplace_back(m, r); rc = &alloc.back();
     }
     if (m != id)
       lc->effect(l, r, m), rc->effect(l, r, m), m = id;

--- a/Structure/dynamic-segtree.cpp
+++ b/Structure/dynamic-segtree.cpp
@@ -1,20 +1,20 @@
+struct DynamicSeg;
+// 必ず vec でなく deque で
+deque<DynamicSeg> alloc;
+
 struct DynamicSeg {
-  static deque<DynamicSeg> alloc;
-  // DynamicSeg *lc = 0, *rc = 0;
-  int lc = -1, rc = -1;
+  DynamicSeg *lc = 0, *rc = 0;
   ll l, r;
   T v;
 
   DynamicSeg(ll L, ll R) : l(L), r(R), v(e) {}
-
-  // 構築 O(1)
   DynamicSeg(ll n) : DynamicSeg(0, n) {}
 
   void _() {
-    if (lc < 0) {
+    if (!lc) {
       ll m = (l + r) / 2;
-      lc = alloc.size(), alloc.emplace_back(l, m);
-      rc = alloc.size(), alloc.emplace_back(m, r);
+      alloc.emplace_back(l, m); lc = &alloc.back();
+      alloc.emplace_back(m, r); rc = &alloc.back();
     }
   }
 
@@ -25,22 +25,18 @@ struct DynamicSeg {
       v = a;
     else if (l <= i && i < r) {
       _();
-      alloc[lc].update(i, a);
-      alloc[rc].update(i, a);
-      auto lv = alloc[lc].v, rv = alloc[rc].v;
+      lc->update(i, a);
+      rc->update(i, a);
+      auto lv = lc->v, rv = rc->v;
       v = op(lv, rv);
     }
   }
 
   T query(ll L, ll R) {
-    if (R <= l || r <= L)
-      return e;
-    if (L <= l && r <= R)
-      return v;
+    if (R <= l || r <= L) return e;
+    if (L <= l && r <= R) return v;
     _();
-    auto lv = alloc[lc].query(L, R), rv = alloc[rc].query(L, R);
+    auto lv = lc->query(L, R), rv = rc->query(L, R);
     return op(lv, rv);
   }
 };
-
-deque<DynamicSeg> DynamicSeg::alloc = {};


### PR DESCRIPTION
もとの実装では new が多用されていて時間・空間計算量の定数倍が良くなかったので修正 (元の状態ではLibrary CheckerがMLEしていた)